### PR TITLE
Add support for video profiles

### DIFF
--- a/idl/VideoCapturer.idl
+++ b/idl/VideoCapturer.idl
@@ -93,16 +93,65 @@ namespace org
       int height;
     };
 
+	enum VideoProfileKind
+	{
+      /// <summary>
+      /// Unspecified video profile kind, for no filtering.
+      /// </summary>
+      unspecified,
+
+	    // These map 1:1 to values of MediaCapture.KnownVideoProfile (with +1 offset).
+      videoRecording,
+      highQualityPhoto,
+      balancedVideoAndPhoto,
+      videoConferencing,
+      photoSequence,
+      highFrameRate,
+      variablePhotoSequence,
+      hdrWithWcgVideo,
+      hdrWithWcgPhoto,
+      videoHdr8,
+	};
+
     [dictionary]
     struct VideoCapturerCreationParameters
     {
       WebRtcFactory factory;
       string name;
+
+      /// <summary>
+      /// Video capture device unique ID to use.
+      /// </summary>
       string id;
+
+      /// <summary>
+      /// Optional unique ID of a video profile to use.
+      /// </summary>
       string videoProfileId;
+
+      /// <summary>
+      /// Optional video profile kind to use.
+      /// </summary>
+      VideoProfileKind videoProfileKind;
+
+      /// <summary>
+      /// Enable Mixed Reality Capture on supported devices.
+      /// </summary>
       bool enableMrc;
+
+      /// <summary>
+      /// Optional constraint on width to select a capture media type (resolution + framerate), or zero for default.
+      /// </summary>
       int width;
+
+      /// <summary>
+      /// Optional constraint on height to select a capture media type (resolution + framerate), or zero for default.
+      /// </summary>
       int height;
+
+      /// <summary>
+      /// Optional constraint on framerate to select a capture media type (resolution + framerate), or zero for default.
+      /// </summary>
       double framerate;
     };
 

--- a/idl/VideoCapturer.idl
+++ b/idl/VideoCapturer.idl
@@ -100,6 +100,9 @@ namespace org
       string name;
       string id;
       bool enableMrc;
+      int width;
+      int height;
+      double framerate;
     };
 
     [disposable]

--- a/idl/VideoCapturer.idl
+++ b/idl/VideoCapturer.idl
@@ -93,14 +93,14 @@ namespace org
       int height;
     };
 
-	enum VideoProfileKind
-	{
+    enum VideoProfileKind
+    {
       /// <summary>
       /// Unspecified video profile kind, for no filtering.
       /// </summary>
-      unspecified,
+      unspecified
 
-	    // These map 1:1 to values of MediaCapture.KnownVideoProfile (with +1 offset).
+      // These map 1:1 to values of MediaCapture.KnownVideoProfile (with +1 offset).
       videoRecording,
       highQualityPhoto,
       balancedVideoAndPhoto,
@@ -111,7 +111,7 @@ namespace org
       hdrWithWcgVideo,
       hdrWithWcgPhoto,
       videoHdr8,
-	};
+    };
 
     [dictionary]
     struct VideoCapturerCreationParameters
@@ -268,13 +268,12 @@ namespace org
 
       [getter]
       VideoCaptureState state;
-	  
+
       /// <summary>
       /// Event fires when a new video frame buffer is available.
       /// </summary>
       [event]
       void onVideoFrame(VideoFrameBufferEvent event);
-	  
     };
   }
 }

--- a/idl/VideoCapturer.idl
+++ b/idl/VideoCapturer.idl
@@ -99,6 +99,7 @@ namespace org
       WebRtcFactory factory;
       string name;
       string id;
+      string videoProfileId;
       bool enableMrc;
       int width;
       int height;

--- a/windows/wrapper/impl_org_webRtc_VideoCapturer.cpp
+++ b/windows/wrapper/impl_org_webRtc_VideoCapturer.cpp
@@ -99,6 +99,7 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
 {
   String name;
   String id;
+  String videoProfileId;
   bool enableMrc {false};
   int width {0};           // unconstrained
   int height {0};          // unconstrained
@@ -109,6 +110,7 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
   if (params) {
     name = params->name;
     id = params->id;
+    videoProfileId = params->videoProfileId;
     enableMrc = params->enableMrc;
     width = params->width;
     height = params->height;
@@ -133,6 +135,7 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
     webrtc::IVideoCapturer::CreationProperties props;
     props.name_ = name.c_str();
     props.id_ = id.c_str();
+    props.videoProfileId_ = videoProfileId.c_str();
     props.mrcEnabled_ = enableMrc;
     props.width_ = width;
     props.height_ = height;

--- a/windows/wrapper/impl_org_webRtc_VideoCapturer.cpp
+++ b/windows/wrapper/impl_org_webRtc_VideoCapturer.cpp
@@ -100,6 +100,8 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
   String name;
   String id;
   String videoProfileId;
+  wrapper::org::webRtc::VideoProfileKind videoProfileKind =
+      wrapper::org::webRtc::VideoProfileKind_unspecified;
   bool enableMrc {false};
   int width {0};           // unconstrained
   int height {0};          // unconstrained
@@ -111,6 +113,7 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
     name = params->name;
     id = params->id;
     videoProfileId = params->videoProfileId;
+    videoProfileKind = params->videoProfileKind;
     enableMrc = params->enableMrc;
     width = params->width;
     height = params->height;
@@ -136,6 +139,7 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
     props.name_ = name.c_str();
     props.id_ = id.c_str();
     props.videoProfileId_ = videoProfileId.c_str();
+    props.videoProfileKind_ = videoProfileKind;
     props.mrcEnabled_ = enableMrc;
     props.width_ = width;
     props.height_ = height;

--- a/windows/wrapper/impl_org_webRtc_VideoCapturer.cpp
+++ b/windows/wrapper/impl_org_webRtc_VideoCapturer.cpp
@@ -100,6 +100,9 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
   String name;
   String id;
   bool enableMrc {false};
+  int width {0};           // unconstrained
+  int height {0};          // unconstrained
+  double framerate {0.0};  // unconstrained
 
   UseFactoryPtr factory = UseFactory::toWrapper(params->factory);
 
@@ -107,6 +110,9 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
     name = params->name;
     id = params->id;
     enableMrc = params->enableMrc;
+    width = params->width;
+    height = params->height;
+    framerate = params->framerate;
   }
 
   std::unique_ptr<::cricket::VideoCapturer> capturer;
@@ -128,6 +134,9 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
     props.name_ = name.c_str();
     props.id_ = id.c_str();
     props.mrcEnabled_ = enableMrc;
+    props.width_ = width;
+    props.height_ = height;
+    props.framerate_ = framerate;
     capturer = NativeTypeUniPtr(dynamic_cast<webrtc::VideoCapturer*>(webrtc::IVideoCapturer::create(props).release()));
     if (!capturer) return {};
   }

--- a/windows/wrapper/impl_webrtc_IMediaStreamSource.h
+++ b/windows/wrapper/impl_webrtc_IMediaStreamSource.h
@@ -48,6 +48,7 @@ namespace webrtc
       IMediaStreamSourceDelegatePtr delegate_;
 
       const char *id_{};
+      const char *videoProfileId_{};
       float frameRateChangeTolerance_ {0.1f};
       int width_{};
       int height_{};

--- a/windows/wrapper/impl_webrtc_IMediaStreamSource.h
+++ b/windows/wrapper/impl_webrtc_IMediaStreamSource.h
@@ -49,6 +49,9 @@ namespace webrtc
 
       const char *id_{};
       float frameRateChangeTolerance_ {0.1f};
+      int width_{};
+      int height_{};
+      double framerate_{};
     };
 
     static IMediaStreamSourcePtr create(const CreationProperties &info) noexcept;

--- a/windows/wrapper/impl_webrtc_IMediaStreamSource.h
+++ b/windows/wrapper/impl_webrtc_IMediaStreamSource.h
@@ -47,12 +47,13 @@ namespace webrtc
       VideoFrameType frameType_ {};
       IMediaStreamSourceDelegatePtr delegate_;
 
-      const char *id_{};
-      const char *videoProfileId_{};
+      const char *id_ {};
+      const char *videoProfileId_ {};
+      int videoProfileKind_ {};
       float frameRateChangeTolerance_ {0.1f};
-      int width_{};
-      int height_{};
-      double framerate_{};
+      int width_ {};
+      int height_ {};
+      double framerate_ {};
     };
 
     static IMediaStreamSourcePtr create(const CreationProperties &info) noexcept;

--- a/windows/wrapper/impl_webrtc_IVideoCapturer.h
+++ b/windows/wrapper/impl_webrtc_IVideoCapturer.h
@@ -61,6 +61,7 @@ namespace webrtc
 
       const char *name_ {};
       const char *id_ {};
+      const char *videoProfileId_ {};
       bool mrcEnabled_ {};
       int width_ {};
       int height_ {};

--- a/windows/wrapper/impl_webrtc_IVideoCapturer.h
+++ b/windows/wrapper/impl_webrtc_IVideoCapturer.h
@@ -62,7 +62,7 @@ namespace webrtc
       const char *name_ {};
       const char *id_ {};
       const char *videoProfileId_ {};
-	    int videoProfileKind_ {};
+      int videoProfileKind_ {};
       bool mrcEnabled_ {};
       int width_ {};
       int height_ {};

--- a/windows/wrapper/impl_webrtc_IVideoCapturer.h
+++ b/windows/wrapper/impl_webrtc_IVideoCapturer.h
@@ -62,6 +62,9 @@ namespace webrtc
       const char *name_ {};
       const char *id_ {};
       bool mrcEnabled_ {};
+      int width_ {};
+      int height_ {};
+      double framerate_ {};
     };
 
     static IVideoCapturerUniPtr create(const CreationProperties &info) noexcept;

--- a/windows/wrapper/impl_webrtc_IVideoCapturer.h
+++ b/windows/wrapper/impl_webrtc_IVideoCapturer.h
@@ -62,6 +62,7 @@ namespace webrtc
       const char *name_ {};
       const char *id_ {};
       const char *videoProfileId_ {};
+	    int videoProfileKind_ {};
       bool mrcEnabled_ {};
       int width_ {};
       int height_ {};

--- a/windows/wrapper/impl_webrtc_VideoCapturer.cpp
+++ b/windows/wrapper/impl_webrtc_VideoCapturer.cpp
@@ -817,7 +817,7 @@ namespace webrtc
         // media type in the list of supported video formats. See also
         // FilterMediaType().
         width_ = desc.Width();
-		    height_ = desc.Height();
+        height_ = desc.Height();
         framerate_ = desc.FrameRate();
 
         settings.VideoProfile(profile);
@@ -974,9 +974,9 @@ namespace webrtc
   {
     auto result = std::make_unique<VideoCapturer>(make_private{});
     if (result->init(info)) {
-	  return result;
+      return result;
     }
-	return {};
+    return {};
   }
 
   //-----------------------------------------------------------------------------
@@ -997,7 +997,7 @@ namespace webrtc
     winrt::Windows::Media::MediaProperties::VideoEncodingProperties
         properties{};
 
-	// Everything from this point is protected by a lock
+    // Everything from this point is protected by a lock
     rtc::CritScope cs(&apiCs_);
 
     // Save device name as UTF8 string
@@ -1185,8 +1185,8 @@ namespace webrtc
     // Note that a MediaCapture object initialized with a specific video profile
     // will filter out results returned by GetAvailableMediaStreamProperties()
     // to the media types available for that profile alone, which is what we want.
-	// In addition, apply the resolution and framerate filters to remove media types
-	// that the caller does not want. See also FindAndAddVideoProfile().
+    // In addition, apply the resolution and framerate filters to remove media types
+    // that the caller does not want. See also FindAndAddVideoProfile().
     std::vector<VideoFormat> formats;
     auto streamProperties =
         mediaCapture.get()
@@ -1221,9 +1221,9 @@ namespace webrtc
              "framerate";
       device_ = nullptr;
       return false;
-	}
+    }
     SetSupportedFormats(formats);
-	return true;
+    return true;
   }
 
   //-----------------------------------------------------------------------------

--- a/windows/wrapper/impl_webrtc_VideoCapturer.cpp
+++ b/windows/wrapper/impl_webrtc_VideoCapturer.cpp
@@ -1114,7 +1114,7 @@ namespace webrtc
           break;
         }
       }
-      if (video_profile_id_.empty()) {
+      if (!video_profile_id_utf16.empty() && video_profile_id_.empty()) {
         RTC_LOG_F(LS_ERROR)
             << "Failed to find video profile " << video_profile_id_utf8
             << " for video capture device " << device_unique_id_utf8;

--- a/windows/wrapper/impl_webrtc_VideoCapturer.cpp
+++ b/windows/wrapper/impl_webrtc_VideoCapturer.cpp
@@ -693,15 +693,14 @@ namespace webrtc
         initialize_task();
       } else {
         // Run asynchronously
-        std::mutex mutex;
         std::condition_variable condition_variable;
-        queue->postClosure([this, &initialize_task, &initialize_async_task,
-                            media_capture_agile, &condition_variable]() {
+        queue->postClosure([&initialize_task, &condition_variable]() {
           initialize_task();
           condition_variable.notify_one();
         });
 
         {
+          std::mutex mutex;
           std::unique_lock<std::mutex> lock(mutex);
           condition_variable.wait(lock);
         }

--- a/windows/wrapper/impl_webrtc_VideoCapturer.h
+++ b/windows/wrapper/impl_webrtc_VideoCapturer.h
@@ -96,6 +96,8 @@ namespace webrtc
       const winrt::com_ptr<IMFSample> &spMediaSample,
       rtc::scoped_refptr<I420BufferInterface> i420Frame);
 
+    bool SetVideoProfile(std::string_view video_profile_id);
+
   private:
     mutable zsLib::RecursiveLock lock_;
 

--- a/windows/wrapper/impl_webrtc_VideoCapturer.h
+++ b/windows/wrapper/impl_webrtc_VideoCapturer.h
@@ -54,7 +54,7 @@ namespace webrtc
     struct make_private {};
 
   private:
-    void init(const CreationProperties &props) noexcept;
+    bool init(const CreationProperties &props) noexcept;
 
   public:
     VideoCapturer(const make_private &);
@@ -114,6 +114,7 @@ namespace webrtc
 
     winrt::hstring device_id_;
     winrt::hstring video_profile_id_;
+    int video_profile_kind_ {};
     std::shared_ptr<CaptureDevice> device_;
     winrt::Windows::Devices::Enumeration::Panel camera_location_;
     std::shared_ptr<DisplayOrientation> display_orientation_;

--- a/windows/wrapper/impl_webrtc_VideoCapturer.h
+++ b/windows/wrapper/impl_webrtc_VideoCapturer.h
@@ -111,6 +111,7 @@ namespace webrtc
     bool apply_rotation_ { false };
 
     winrt::hstring device_id_;
+    winrt::hstring video_profile_id_;
     std::shared_ptr<CaptureDevice> device_;
     winrt::Windows::Devices::Enumeration::Panel camera_location_;
     std::shared_ptr<DisplayOrientation> display_orientation_;


### PR DESCRIPTION
Add the ability to select the video profile of a video capture device by unique string identifier, and to select a particular resolution and/or framerate within that profile.

For consistency, also add the ability to select the resolution and/or framerate when not using video profiles, as it seems that WebRTC media constraints are deprecated and being removed : https://bugs.chromium.org/p/webrtc/issues/detail?id=9239