### PR TITLE
Wait for StopCapture() to finish before returning

### DIFF
--- a/windows/wrapper/impl_webrtc_VideoCapturer.cpp
+++ b/windows/wrapper/impl_webrtc_VideoCapturer.cpp
@@ -612,7 +612,7 @@ namespace webrtc
           "CaptureDevice::StopCapture: Stop failed, reason: '" <<
           rtc::ToUtf8(e.message().c_str()) << "'";
       }
-    });
+    }).wait();
   }
 
   //-----------------------------------------------------------------------------


### PR DESCRIPTION
Ensure StopCapture() finished stopping and cleaning up the capture
device before it returns. Otherwise subsequent calls to the media
capture device might proceed to access it in parallel of that work,
creating a race condition.

This fixes webrtc-uwp/webrtc-uwp-sdk#189.