### PR TITLE
Add support for MRC recording indicator

### DIFF
--- a/idl/VideoCapturer.idl
+++ b/idl/VideoCapturer.idl
@@ -140,6 +140,11 @@ namespace org
       bool enableMrc;
 
       /// <summary>
+      /// If Mixed Reality Capture is enabled, enable the recording indicator on screen.
+      /// </summary>
+      bool enableMrcRecordingIndicator;
+
+      /// <summary>
       /// Optional constraint on width to select a capture media type (resolution + framerate), or zero for default.
       /// </summary>
       int width;

--- a/windows/wrapper/impl_org_webRtc_VideoCapturer.cpp
+++ b/windows/wrapper/impl_org_webRtc_VideoCapturer.cpp
@@ -103,6 +103,7 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
   wrapper::org::webRtc::VideoProfileKind videoProfileKind =
       wrapper::org::webRtc::VideoProfileKind_unspecified;
   bool enableMrc {false};
+  bool enableMrcRecordingIndicator {true};
   int width {0};           // unconstrained
   int height {0};          // unconstrained
   double framerate {0.0};  // unconstrained
@@ -115,6 +116,7 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
     videoProfileId = params->videoProfileId;
     videoProfileKind = params->videoProfileKind;
     enableMrc = params->enableMrc;
+    enableMrcRecordingIndicator = params->enableMrcRecordingIndicator;
     width = params->width;
     height = params->height;
     framerate = params->framerate;
@@ -141,6 +143,7 @@ wrapper::org::webRtc::VideoCapturerPtr wrapper::org::webRtc::VideoCapturer::crea
     props.videoProfileId_ = videoProfileId.c_str();
     props.videoProfileKind_ = videoProfileKind;
     props.mrcEnabled_ = enableMrc;
+    props.mrcRecordingIndicatorEnabled_ = enableMrcRecordingIndicator;
     props.width_ = width;
     props.height_ = height;
     props.framerate_ = framerate;

--- a/windows/wrapper/impl_webrtc_IVideoCapturer.h
+++ b/windows/wrapper/impl_webrtc_IVideoCapturer.h
@@ -64,6 +64,7 @@ namespace webrtc
       const char *videoProfileId_ {};
       int videoProfileKind_ {};
       bool mrcEnabled_ {};
+      bool mrcRecordingIndicatorEnabled_ {};
       int width_ {};
       int height_ {};
       double framerate_ {};

--- a/windows/wrapper/impl_webrtc_VideoCapturer.cpp
+++ b/windows/wrapper/impl_webrtc_VideoCapturer.cpp
@@ -237,7 +237,7 @@ namespace webrtc
 
     void StartCapture(winrt::Windows::Media::MediaProperties::MediaEncodingProfile const& media_encoding_profile,
       winrt::Windows::Media::MediaProperties::IVideoEncodingProperties const& video_encoding_properties,
-      bool mrc_enabled);
+      bool mrc_enabled, bool mrc_recording_indicator_enabled);
 
     void StopCapture();
 
@@ -479,7 +479,7 @@ namespace webrtc
   void CaptureDevice::StartCapture(
     MediaEncodingProfile const& media_encoding_profile,
     IVideoEncodingProperties const& video_encoding_properties,
-    bool mrc_enabled) {
+    bool mrc_enabled, bool mrc_recording_indicator_enabled) {
     // Ensure StartCapture() is not called twice
     if (capture_started_) {
       winrt::throw_hresult(ERROR_INVALID_STATE);
@@ -547,12 +547,13 @@ namespace webrtc
       mediaExtension.as(media_sink_);
       return mediaExtension;
     }).then([this, media_encoding_profile,
-        video_encoding_properties, mrc_enabled](IMediaExtension const& media_extension) {
+        video_encoding_properties, mrc_enabled, mrc_recording_indicator_enabled](IMediaExtension const& media_extension) {
       // Add MRC if the device supports it and caller requested it
       winrt::hstring deviceFamily = winrt::Windows::System::Profile::AnalyticsInfo::VersionInfo().DeviceFamily();
       if (std::wstring(deviceFamily.c_str()).compare((L"Windows.Holographic")) == 0 && mrc_enabled) {
         MrcVideoEffectDefinition mrcVideoEffectDefinition;
         mrcVideoEffectDefinition.StreamType(MediaStreamType::VideoRecord);
+        mrcVideoEffectDefinition.RecordingIndicatorEnabled(mrc_recording_indicator_enabled);
         auto addEffectTask = Concurrency::create_task([this, &mrcVideoEffectDefinition]() {
           return media_capture_.get().AddVideoEffectAsync(mrcVideoEffectDefinition, MediaStreamType::VideoRecord).get();
         }).then([this](IMediaExtension const& /* videoExtension */)
@@ -1024,6 +1025,7 @@ namespace webrtc
 
     SetId(String(props.id_));
     mrc_enabled_ = props.mrcEnabled_;
+    mrc_recording_indicator_enabled_ = props.mrcRecordingIndicatorEnabled_;
 
     if (props.delegate_) {
       defaultSubscription_ = subscriptions_.subscribe(
@@ -1380,7 +1382,7 @@ namespace webrtc
     try {
       ApplyDisplayOrientation(display_orientation_->Orientation());
       device_->StartCapture(media_encoding_profile_,
-        video_encoding_properties_, mrc_enabled_);
+        video_encoding_properties_, mrc_enabled_, mrc_recording_indicator_enabled_);
     } catch (winrt::hresult_error const& e) {
       RTC_LOG(LS_ERROR) << "Failed to start capture. "
         << rtc::ToUtf8(e.message().c_str());

--- a/windows/wrapper/impl_webrtc_VideoCapturer.h
+++ b/windows/wrapper/impl_webrtc_VideoCapturer.h
@@ -144,7 +144,11 @@ namespace webrtc
     winrt::Windows::Media::MediaProperties::MediaEncodingProfile
       media_encoding_profile_;
 
-    bool mrc_enabled_{ false };
+	/// Enable Mixed Reality Capture.
+    bool mrc_enabled_{false};
+
+	/// Enable the on-screen recording indicator when MRC is active.
+    bool mrc_recording_indicator_enabled_{true};
   };
 }
 


### PR DESCRIPTION
Enable toggling ON and OFF the on-screen recording indicator while Mixed
Reality Capture (MRC) is in use.